### PR TITLE
change column name type to record_type

### DIFF
--- a/cassandra/db.go
+++ b/cassandra/db.go
@@ -21,13 +21,14 @@ package cassandra
 
 import (
 	"errors"
+	"time"
+
 	"github.com/InVisionApp/go-health"
 	"github.com/go-kit/kit/metrics/provider"
 	"github.com/goph/emperror"
 	db "github.com/xmidt-org/codex-db"
 	"github.com/xmidt-org/codex-db/blacklist"
 	"github.com/yugabyte/gocql"
-	"time"
 )
 
 var (
@@ -157,7 +158,7 @@ func (c *Connection) GetRecords(deviceID string, limit int) ([]db.Record, error)
 
 // GetRecords returns a list of records for a given device and event type.
 func (c *Connection) GetRecordsOfType(deviceID string, limit int, eventType db.EventType) ([]db.Record, error) {
-	deviceInfo, err := c.finder.findRecords(limit, "WHERE device_id = ? AND type = ?", deviceID, eventType)
+	deviceInfo, err := c.finder.findRecords(limit, "WHERE device_id = ? AND record_type = ?", deviceID, eventType)
 	if err != nil {
 		c.measures.SQLQueryFailureCount.With(db.TypeLabel, db.ReadType).Add(1.0)
 		return []db.Record{}, emperror.WrapWith(err, "Getting records from database failed", "device id", deviceID)

--- a/db.go
+++ b/db.go
@@ -37,7 +37,7 @@ const (
 // metadata to be used for the record.  If the data is encrypted, the Nonce,
 // Alg, and KID values will be needed to determine how to correctly decrypt it.
 type Record struct {
-	Type      EventType `json:"type" bson:"type" gorm:"type:int"`
+	Type      EventType `json:"recordtype" bson:"recordtype" gorm:"recordtype:int"`
 	DeviceID  string    `json:"deviceid" bson:"deviceid"`
 	BirthDate int64     `json:"birthdate" bson:"birthdate"`
 	DeathDate int64     `json:"deathdate" bson:"deathdate"`

--- a/postgresql/db.go
+++ b/postgresql/db.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/xmidt-org/codex-db"
+	db "github.com/xmidt-org/codex-db"
 	"github.com/xmidt-org/codex-db/blacklist"
 
 	"github.com/go-kit/kit/metrics/provider"
@@ -268,7 +268,7 @@ func (c *Connection) GetRecordsOfType(deviceID string, limit int, eventType db.E
 	var (
 		deviceInfo []db.Record
 	)
-	err := c.finder.findRecords(&deviceInfo, limit, "device_id = ? AND type = ?", deviceID, eventType)
+	err := c.finder.findRecords(&deviceInfo, limit, "device_id = ? AND record_type = ?", deviceID, eventType)
 	if err != nil {
 		c.measures.SQLQueryFailureCount.With(db.TypeLabel, db.ReadType).Add(1.0)
 		return []db.Record{}, emperror.WrapWith(err, "Getting records from database failed", "device id", deviceID)


### PR DESCRIPTION
Hi @kcajmagic 
I made the changes that you requested on issue #8 
What I did:
- I search `type` on your repo one by one, what i found that query with column name type is in 2 packages, cassandra and postgresql. I also searched in executor.go files, which have query inside. cassandra executor has no `type` column, it's already `record_type`. and in postgresql executor has no column names `type` or `record_type`.
- I changed the json, bson and gorm name which was `type` at the first to `recordtype`, since, i don't know if this is needed or not, if it's not needed, i'll change it back to type. because this one is the top json structure, even the name of struct is Record. that doesn't specify the json name. it would look like this
```
{
    "type": 1,
    "deviceid": 1
}
```
to
```
{
    "recordtype": 1,
    "deviceid": 1
}
```