### PR TITLE
Modified retry package to use backoff package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Modified retry package to use backoff package for exponential backoffs on retries [#21](https://github.com/xmidt-org/codex-db/pull/21)
 
 ## [v0.3.3]
 - fix read error causing corrupt data

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/gorm v1.9.10
 	github.com/stretchr/testify v1.4.0
 	github.com/xmidt-org/capacityset v0.1.1
-	github.com/xmidt-org/webpa-common v1.4.0
+	github.com/xmidt-org/webpa-common v1.5.0
 	github.com/xmidt-org/wrp-go v1.3.4
 
 	github.com/yugabyte/gocql v0.0.0-20190522232832-e049977574e9

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/InVisionApp/go-health/v2 v2.1.2
 	github.com/InVisionApp/go-logger v1.0.1
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
+	github.com/cenkalti/backoff/v3 v3.1.1
 	github.com/go-kit/kit v0.9.0
 
 	github.com/goph/emperror v0.17.3-0.20190703203600-60a8d9faa17b

--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,6 @@ github.com/bugsnag/bugsnag-go v1.4.0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqR
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/c9s/goprocinfo v0.0.0-20151025191153-19cb9f127a9c/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
 github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
@@ -304,8 +303,8 @@ github.com/xmidt-org/webpa-common v1.2.0 h1:ewB82rL5vpiY1hgt2PhG4oKGad67tH4sdIZL
 github.com/xmidt-org/webpa-common v1.2.0/go.mod h1:oCpKzOC+9h2vYHVzAU/06tDTQuBN4RZz+rhgIXptpOI=
 github.com/xmidt-org/webpa-common v1.3.1/go.mod h1:oCpKzOC+9h2vYHVzAU/06tDTQuBN4RZz+rhgIXptpOI=
 github.com/xmidt-org/webpa-common v1.3.2/go.mod h1:oCpKzOC+9h2vYHVzAU/06tDTQuBN4RZz+rhgIXptpOI=
-github.com/xmidt-org/webpa-common v1.4.0 h1:/QXVz20OzElMWbzV/NtF1CtRmWWJ2nBtGjQjns9Q0tI=
-github.com/xmidt-org/webpa-common v1.4.0/go.mod h1:QfoOzMY8joK0KMbcCO4KhtUcEps2Tu4j4CYV2k84ggA=
+github.com/xmidt-org/webpa-common v1.5.0 h1:HbLwhkSITrwBn2I/FsHRsimXXzUoOOUvoeCvAx0mq4s=
+github.com/xmidt-org/webpa-common v1.5.0/go.mod h1:wR27EP2MfUvQNy22rYm9p65VSErlwTi34mDCWhZivgI=
 github.com/xmidt-org/wrp-go v1.3.3/go.mod h1:VOKYeeVWc2cyYmGWJksqUCV/lGzReRl0EP74y3mcWp0=
 github.com/xmidt-org/wrp-go v1.3.4 h1:7kj+1VXRNNEI7G0Z3z7C58QpIXrWzTw/eI79FdAhyPA=
 github.com/xmidt-org/wrp-go v1.3.4/go.mod h1:EWC9BgcYYO1hKgLzz6VFPpg3LU6ZWSDV/uNiWC7zP+o=

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,9 @@ github.com/bugsnag/bugsnag-go v1.4.0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqR
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/c9s/goprocinfo v0.0.0-20151025191153-19cb9f127a9c/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
+github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,7 +15,7 @@
  *
  */
 
-// package dbretry contains structs that implement various db interfaces as
+// Package dbretry contains structs that implement various db interfaces as
 // well as consume them.  They allow consumers to easily try to interact with
 // the database a configurable number of times, with configurable backoff
 // options and metrics.
@@ -24,78 +24,35 @@ package dbretry
 import (
 	"time"
 
-	"github.com/xmidt-org/codex-db"
-	"github.com/xmidt-org/codex-db/blacklist"
-
+	"github.com/cenkalti/backoff/v3"
 	"github.com/go-kit/kit/metrics/provider"
-)
-
-const (
-	defaultInterval     = time.Second
-	defaultIntervalMult = 1
-	defaultRetries      = 1
+	db "github.com/xmidt-org/codex-db"
 )
 
 var (
-	defaultSleep = time.Sleep
+	defaultBackoff = backoff.ExponentialBackOff{
+		InitialInterval:     time.Second,
+		RandomizationFactor: 0.1,
+		Multiplier:          5,
+		MaxInterval:         7 * time.Second,
+		MaxElapsedTime:      10 * time.Second,
+		Clock:               backoff.SystemClock,
+	}
 )
 
 type retryConfig struct {
-	retries      int
-	interval     time.Duration
-	intervalMult time.Duration
-	sleep        func(time.Duration)
-	measures     Measures
+	backoffConfig backoff.ExponentialBackOff
+	measures      Measures
 }
 
 // Option is the function used to configure the retry objects.
 type Option func(r *retryConfig)
 
-// WithRetries sets the number of times to potentially try to interact with the
-// database if the inital attempt doesn't succeed.
-func WithRetries(retries int) Option {
+// WithBackoff sets the backoff to use when retrying.  By default, this is
+// an exponential backoff.
+func WithBackoff(b backoff.ExponentialBackOff) Option {
 	return func(r *retryConfig) {
-		// only set retries if the value is valid
-		if retries >= 0 {
-			r.retries = retries
-		}
-	}
-}
-
-// WithInterval sets the amount of time to wait between the initial attempt and
-// the first retry.  If the interval multiplier is 1, this interval is used
-// between every attempt.
-func WithInterval(interval time.Duration) Option {
-	return func(r *retryConfig) {
-		// only set interval if the value is valid
-		if interval > time.Duration(0)*time.Second {
-			r.interval = interval
-		}
-	}
-}
-
-// WithIntervalMultiplier sets the interval multiplier, which is multiplied
-// against the interval time for each wait time after the first retry.  For
-// example, if the interval is 1s, the interval multiplier 5, and the number of
-// retries 3, then between the initial attempt and first retry, the program
-// will wait 1s.  Between the first retry and the second retry, the program
-// will wait 5s.  Between the second retry and the third, the program will
-// wait 25s.  This is assuming all attempts fail.
-func WithIntervalMultiplier(mult time.Duration) Option {
-	return func(r *retryConfig) {
-		if mult > 1 {
-			r.intervalMult = mult
-		}
-	}
-}
-
-// WithSleep sets the function used for sleeping.  By default, this is
-// time.Sleep.
-func WithSleep(sleep func(time.Duration)) Option {
-	return func(r *retryConfig) {
-		if sleep != nil {
-			r.sleep = sleep
-		}
+		r.backoffConfig = b
 	}
 }
 
@@ -115,30 +72,27 @@ type RetryInsertService struct {
 	config   retryConfig
 }
 
+// AddRetryMetric is a function to add to our metrics when we retry.  The
+// function is passed to the backoff package and is called when we are retrying.
+func (ri RetryInsertService) AddRetryMetric(_ error, _ time.Duration) {
+	ri.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.InsertType).Add(1.0)
+}
+
 // InsertRecords uses the inserter to insert the records and tries again if
 // inserting fails.  Between each try, it calculates how long to wait and then
 // waits for that period of time before trying again. Only the error from the
 // last failure is returned.
 func (ri RetryInsertService) InsertRecords(records ...db.Record) error {
-	var err error
 
-	retries := ri.config.retries
-	if retries < 1 {
-		retries = 0
+	insertFunc := func() error {
+		return ri.inserter.InsertRecords(records...)
 	}
 
-	sleepTime := ri.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			ri.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.InsertType).Add(1.0)
-			ri.config.sleep(sleepTime)
-			sleepTime = sleepTime * ri.config.intervalMult
-		}
-		if err = ri.inserter.InsertRecords(records...); err == nil {
-			break
-		}
-	}
+	// with every insert, we have to make a copy of the ExponentialBackoff
+	// struct, as it is not thread safe, and each thread needs its own clock.
+	b := ri.config.backoffConfig
 
+	err := backoff.RetryNotify(insertFunc, &b, ri.AddRetryMetric)
 	ri.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.InsertType).Add(1.0)
 	return err
 }
@@ -149,236 +103,11 @@ func CreateRetryInsertService(inserter db.Inserter, options ...Option) RetryInse
 	ris := RetryInsertService{
 		inserter: inserter,
 		config: retryConfig{
-			retries:      defaultRetries,
-			interval:     defaultInterval,
-			intervalMult: defaultIntervalMult,
-			sleep:        defaultSleep,
+			backoffConfig: defaultBackoff,
 		},
 	}
 	for _, o := range options {
 		o(&ris.config)
 	}
 	return ris
-}
-
-// RetryUpdateService is a wrapper for a db.Pruner that attempts either part of
-// the pruning process a configurable number of times.
-type RetryUpdateService struct {
-	pruner db.Pruner
-	config retryConfig
-}
-
-// GetRecordsToDelete uses the pruner to get records and tries again if
-// getting fails.  Between each try, it calculates how long to wait and then
-// waits for that period of time before trying again. Only the error from the
-// last failure is returned.
-func (ru RetryUpdateService) GetRecordsToDelete(shard int, limit int, deathDate int64) ([]db.RecordToDelete, error) {
-	var (
-		err       error
-		recordIDs []db.RecordToDelete
-	)
-
-	retries := ru.config.retries
-	if retries < 1 {
-		retries = 0
-	}
-
-	sleepTime := ru.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			ru.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-			ru.config.sleep(sleepTime)
-			sleepTime = sleepTime * ru.config.intervalMult
-		}
-		if recordIDs, err = ru.pruner.GetRecordsToDelete(shard, limit, deathDate); err == nil {
-			break
-		}
-	}
-
-	ru.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-	return recordIDs, err
-}
-
-// DeleteRecord uses the pruner to delete a record and tries again if
-// deleting fails.  Between each try, it calculates how long to wait and then
-// waits for that period of time before trying again. Only the error from the
-// last failure is returned.
-func (ru RetryUpdateService) DeleteRecord(shard int, deathdate int64, recordID int64) error {
-	var err error
-
-	retries := ru.config.retries
-	if retries < 1 {
-		retries = 0
-	}
-
-	sleepTime := ru.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			ru.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.DeleteType).Add(1.0)
-			ru.config.sleep(sleepTime)
-			sleepTime = sleepTime * ru.config.intervalMult
-		}
-		if err = ru.pruner.DeleteRecord(shard, deathdate, recordID); err == nil {
-			break
-		}
-	}
-
-	ru.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.DeleteType).Add(1.0)
-	return err
-}
-
-// CreateRetryUpdateService takes a pruner and the options provided and creates
-// a RetryUpdateService.
-func CreateRetryUpdateService(pruner db.Pruner, options ...Option) RetryUpdateService {
-	rus := RetryUpdateService{
-		pruner: pruner,
-		config: retryConfig{
-			retries:      defaultRetries,
-			interval:     defaultInterval,
-			intervalMult: defaultIntervalMult,
-			sleep:        defaultSleep,
-		},
-	}
-	for _, o := range options {
-		o(&rus.config)
-	}
-	return rus
-}
-
-// RetryListGService is a wrapper for a blacklist Updater that attempts to
-// get the blacklist a configurable number of times if the gets fail.
-type RetryListGService struct {
-	lg     blacklist.Updater
-	config retryConfig
-}
-
-// GetBlacklist uses the updater to get the blacklist and tries again if
-// getting fails.  Between each try, it calculates how long to wait and then
-// waits for that period of time before trying again. Only the error from the
-// last failure is returned.
-func (ltg RetryListGService) GetBlacklist() (list []blacklist.BlackListedItem, err error) {
-	retries := ltg.config.retries
-	if retries < 1 {
-		retries = 0
-	}
-
-	sleepTime := ltg.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			ltg.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.BlacklistReadType).Add(1.0)
-			ltg.config.sleep(sleepTime)
-			sleepTime = sleepTime * ltg.config.intervalMult
-		}
-		if list, err = ltg.lg.GetBlacklist(); err == nil {
-			break
-		}
-	}
-
-	ltg.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.BlacklistReadType).Add(1.0)
-	return
-}
-
-// CreateRetryListGService takes an updater and the options provided and creates
-// a RetryListGService.
-func CreateRetryListGService(listGetter blacklist.Updater, options ...Option) RetryListGService {
-	rlgs := RetryListGService{
-		lg: listGetter,
-		config: retryConfig{
-			retries:      defaultRetries,
-			interval:     defaultInterval,
-			intervalMult: defaultIntervalMult,
-			sleep:        defaultSleep,
-		},
-	}
-	for _, o := range options {
-		o(&rlgs.config)
-	}
-	return rlgs
-}
-
-// RetryRGService is a wrapper for a record getter that attempts to
-// get records for a device a configurable number of times if the gets fail.
-type RetryRGService struct {
-	rg     db.RecordGetter
-	config retryConfig
-}
-
-// GetRecords uses the getter to get records for a device and tries again if
-// getting fails.  Between each try, it calculates how long to wait and then
-// waits for that period of time before trying again. Only the error from the
-// last failure is returned.
-func (rtg RetryRGService) GetRecords(deviceID string, limit int) ([]db.Record, error) {
-	var (
-		err    error
-		record []db.Record
-	)
-
-	retries := rtg.config.retries
-	if retries < 1 {
-		retries = 0
-	}
-
-	sleepTime := rtg.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			rtg.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-			rtg.config.sleep(sleepTime)
-			sleepTime = sleepTime * rtg.config.intervalMult
-		}
-		if record, err = rtg.rg.GetRecords(deviceID, limit); err == nil {
-			break
-		}
-	}
-
-	rtg.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-	return record, err
-}
-
-// GetRecordsOfType uses the getter to get records of a specified type for a
-// device and tries again if getting fails.  Between each try, it calculates
-// how long to wait and then waits for that period of time before trying again.
-// Only the error from the last failure is returned.
-func (rtg RetryRGService) GetRecordsOfType(deviceID string, limit int, eventType db.EventType) ([]db.Record, error) {
-	var (
-		err    error
-		record []db.Record
-	)
-
-	retries := rtg.config.retries
-	if retries < 1 {
-		retries = 0
-	}
-
-	sleepTime := rtg.config.interval
-	for i := 0; i < retries+1; i++ {
-		if i > 0 {
-			rtg.config.measures.SQLQueryRetryCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-			rtg.config.sleep(sleepTime)
-			sleepTime = sleepTime * rtg.config.intervalMult
-		}
-		if record, err = rtg.rg.GetRecordsOfType(deviceID, limit, eventType); err == nil {
-			break
-		}
-	}
-
-	rtg.config.measures.SQLQueryEndCount.With(db.TypeLabel, db.ReadType).Add(1.0)
-	return record, err
-}
-
-// CreateRetryRGService takes a record getter and the options provided and
-// creates a RetryRGService.
-func CreateRetryRGService(recordGetter db.RecordGetter, options ...Option) RetryRGService {
-	rrgs := RetryRGService{
-		rg: recordGetter,
-		config: retryConfig{
-			retries:      defaultRetries,
-			interval:     defaultInterval,
-			intervalMult: defaultIntervalMult,
-			sleep:        defaultSleep,
-		},
-	}
-	for _, o := range options {
-		o(&rrgs.config)
-	}
-	return rrgs
 }

--- a/retry/retry_mocks_test.go
+++ b/retry/retry_mocks_test.go
@@ -19,8 +19,7 @@ package dbretry
 
 import (
 	"github.com/stretchr/testify/mock"
-	"github.com/xmidt-org/codex-db"
-	"github.com/xmidt-org/codex-db/blacklist"
+	db "github.com/xmidt-org/codex-db"
 )
 
 type mockInserter struct {
@@ -30,41 +29,4 @@ type mockInserter struct {
 func (i *mockInserter) InsertRecords(records ...db.Record) error {
 	args := i.Called(records)
 	return args.Error(0)
-}
-
-type mockPruner struct {
-	mock.Mock
-}
-
-func (p *mockPruner) GetRecordsToDelete(shard int, limit int, deathDate int64) ([]db.RecordToDelete, error) {
-	args := p.Called(shard, limit, deathDate)
-	return args.Get(0).([]db.RecordToDelete), args.Error(1)
-}
-
-func (p *mockPruner) DeleteRecord(shard int, deathdate int64, recordID int64) error {
-	args := p.Called(shard, deathdate, recordID)
-	return args.Error(0)
-}
-
-type mockRG struct {
-	mock.Mock
-}
-
-func (rg *mockRG) GetRecords(deviceID string, limit int) ([]db.Record, error) {
-	args := rg.Called(deviceID, limit)
-	return args.Get(0).([]db.Record), args.Error(1)
-}
-
-func (rg *mockRG) GetRecordsOfType(deviceID string, limit int, eventType db.EventType) ([]db.Record, error) {
-	args := rg.Called(deviceID, limit, eventType)
-	return args.Get(0).([]db.Record), args.Error(1)
-}
-
-type mockLG struct {
-	mock.Mock
-}
-
-func (rg *mockLG) GetBlacklist() ([]blacklist.BlackListedItem, error) {
-	args := rg.Called()
-	return args.Get(0).([]blacklist.BlackListedItem), args.Error(1)
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -22,53 +22,45 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xmidt-org/codex-db"
-	"github.com/xmidt-org/codex-db/blacklist"
+	"github.com/cenkalti/backoff/v3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	db "github.com/xmidt-org/codex-db"
 	"github.com/xmidt-org/webpa-common/xmetrics/xmetricstest"
 )
 
 func TestRetryInsertRecords(t *testing.T) {
 	initialErr := errors.New("test initial error")
 	failureErr := errors.New("test final error")
-	interval := time.Duration(8) * time.Second
 	tests := []struct {
 		description         string
 		numCalls            int
-		retries             int
+		maxElapsedTime      time.Duration
 		expectedRetryMetric float64
 		finalError          error
 		expectedErr         error
 	}{
 		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
+			description:    "Initial Success",
+			numCalls:       1,
+			maxElapsedTime: 1,
+			finalError:     nil,
+			expectedErr:    nil,
 		},
 		{
 			description:         "Eventual Success",
 			numCalls:            3,
-			retries:             5,
+			maxElapsedTime:      1 * time.Minute,
 			expectedRetryMetric: 2.0,
 			finalError:          nil,
 			expectedErr:         nil,
 		},
 		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
 			description:         "Eventual Failure",
 			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
+			maxElapsedTime:      10 * time.Millisecond,
+			expectedRetryMetric: -1,
 			finalError:          failureErr,
 			expectedErr:         failureErr,
 		},
@@ -81,7 +73,11 @@ func TestRetryInsertRecords(t *testing.T) {
 				mockObj.On("InsertRecords", mock.Anything).Return(initialErr).Times(tc.numCalls - 1)
 			}
 			if tc.numCalls > 0 {
-				mockObj.On("InsertRecords", mock.Anything).Return(tc.finalError).Once()
+				if tc.finalError == nil {
+					mockObj.On("InsertRecords", mock.Anything).Return(nil).Once()
+				} else {
+					mockObj.On("InsertRecords", mock.Anything).Return(tc.finalError)
+				}
 			}
 			p := xmetricstest.NewProvider(nil, Metrics)
 			m := NewMeasures(p)
@@ -89,11 +85,13 @@ func TestRetryInsertRecords(t *testing.T) {
 			retryInsertService := RetryInsertService{
 				inserter: mockObj,
 				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
+					backoffConfig: backoff.ExponentialBackOff{
+						InitialInterval:     1,
+						RandomizationFactor: 0,
+						Multiplier:          10,
+						MaxInterval:         2000,
+						MaxElapsedTime:      tc.maxElapsedTime,
+						Clock:               backoff.SystemClock,
 					},
 					measures: m,
 				},
@@ -102,7 +100,9 @@ func TestRetryInsertRecords(t *testing.T) {
 			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
 			err := retryInsertService.InsertRecords(db.Record{})
 			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.InsertType)(xmetricstest.Value(tc.expectedRetryMetric))
+			if tc.expectedRetryMetric >= 0 {
+				p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.InsertType)(xmetricstest.Value(tc.expectedRetryMetric))
+			}
 			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.InsertType)(xmetricstest.Value(1.0))
 			if tc.expectedErr == nil || err == nil {
 				assert.Equal(tc.expectedErr, err)
@@ -113,494 +113,54 @@ func TestRetryInsertRecords(t *testing.T) {
 	}
 }
 
+type constClock struct{}
+
+func (c *constClock) Now() time.Time {
+	return time.Unix(0, 0)
+}
+
 func TestCreateRetryInsertService(t *testing.T) {
 	r := RetryInsertService{
 		inserter: new(mockInserter),
 		config: retryConfig{
-			retries:      322,
-			interval:     2 * time.Minute,
-			intervalMult: 1,
+			backoffConfig: backoff.ExponentialBackOff{
+				InitialInterval:     30,
+				RandomizationFactor: 0.01,
+				Multiplier:          200,
+				MaxInterval:         50000,
+				MaxElapsedTime:      0,
+				Clock:               &constClock{},
+			},
 		},
 	}
 	assert := assert.New(t)
 	p := xmetricstest.NewProvider(nil, Metrics)
-	newService := CreateRetryInsertService(r.inserter, WithRetries(r.config.retries), WithInterval(r.config.interval), WithMeasures(p))
+	newService := CreateRetryInsertService(r.inserter, WithBackoff(r.config.backoffConfig), WithMeasures(p))
 	assert.Equal(r.inserter, newService.inserter)
-	assert.Equal(r.config.retries, newService.config.retries)
-	assert.Equal(r.config.interval, newService.config.interval)
-	assert.Equal(r.config.intervalMult, newService.config.intervalMult)
+	assert.Equal(r.config.backoffConfig, newService.config.backoffConfig)
 }
 
-func TestRetryGetRecordIDs(t *testing.T) {
-	initialErr := errors.New("test initial error")
-	failureErr := errors.New("test final error")
-	interval := 8 * time.Second
-	tests := []struct {
-		description         string
-		numCalls            int
-		retries             int
-		expectedRetryMetric float64
-		finalError          error
-		expectedErr         error
-	}{
-		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
-		},
-		{
-			description:         "Eventual Success",
-			numCalls:            3,
-			retries:             5,
-			expectedRetryMetric: 2.0,
-			finalError:          nil,
-			expectedErr:         nil,
-		},
-		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
-			description:         "Eventual Failure",
-			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
-			finalError:          failureErr,
-			expectedErr:         failureErr,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			mockObj := new(mockPruner)
-			if tc.numCalls > 1 {
-				mockObj.On("GetRecordsToDelete", mock.Anything, mock.Anything, mock.Anything).Return([]db.RecordToDelete{}, initialErr).Times(tc.numCalls - 1)
-			}
-			if tc.numCalls > 0 {
-				mockObj.On("GetRecordsToDelete", mock.Anything, mock.Anything, mock.Anything).Return([]db.RecordToDelete{}, tc.finalError).Once()
-			}
-			p := xmetricstest.NewProvider(nil, Metrics)
-			m := NewMeasures(p)
-
-			retryUpdateService := RetryUpdateService{
-				pruner: mockObj,
-				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
-					},
-					measures: m,
-				},
-			}
-			p.Assert(t, SQLQueryRetryCounter)(xmetricstest.Value(0.0))
-			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
-			_, err := retryUpdateService.GetRecordsToDelete(0, 0, time.Now().UnixNano())
-			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(tc.expectedRetryMetric))
-			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(1.0))
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-
-}
-
-func TestRetryPruneRecords(t *testing.T) {
-	initialErr := errors.New("test initial error")
-	failureErr := errors.New("test final error")
-	interval := 8 * time.Second
-	tests := []struct {
-		description         string
-		numCalls            int
-		retries             int
-		expectedRetryMetric float64
-		finalError          error
-		expectedErr         error
-	}{
-		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
-		},
-		{
-			description:         "Eventual Success",
-			numCalls:            3,
-			retries:             5,
-			expectedRetryMetric: 2.0,
-			finalError:          nil,
-			expectedErr:         nil,
-		},
-		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
-			description:         "Eventual Failure",
-			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
-			finalError:          failureErr,
-			expectedErr:         failureErr,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			mockObj := new(mockPruner)
-			if tc.numCalls > 1 {
-				mockObj.On("DeleteRecord", mock.Anything, mock.Anything, mock.Anything).Return(initialErr).Times(tc.numCalls - 1)
-			}
-			if tc.numCalls > 0 {
-				mockObj.On("DeleteRecord", mock.Anything, mock.Anything, mock.Anything).Return(tc.finalError).Once()
-			}
-			p := xmetricstest.NewProvider(nil, Metrics)
-			m := NewMeasures(p)
-
-			retryUpdateService := RetryUpdateService{
-				pruner: mockObj,
-				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
-					},
-					measures: m,
-				},
-			}
-			p.Assert(t, SQLQueryRetryCounter)(xmetricstest.Value(0.0))
-			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
-			err := retryUpdateService.DeleteRecord(0, 0, 0)
-			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.DeleteType)(xmetricstest.Value(tc.expectedRetryMetric))
-			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.DeleteType)(xmetricstest.Value(1.0))
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-
-}
-
-func TestCreateRetryUpdateService(t *testing.T) {
-	r := RetryUpdateService{
-		pruner: new(mockPruner),
+func TestCreateRetryInsertServiceUseDefaults(t *testing.T) {
+	r := RetryInsertService{
+		inserter: new(mockInserter),
 		config: retryConfig{
-			retries:      322,
-			interval:     2 * time.Minute,
-			intervalMult: 8,
+			backoffConfig: backoff.ExponentialBackOff{
+				InitialInterval:     -10,
+				RandomizationFactor: -1,
+				Multiplier:          0,
+				MaxInterval:         -10,
+				MaxElapsedTime:      -1,
+				Clock:               nil,
+			},
 		},
 	}
 	assert := assert.New(t)
-	p := xmetricstest.NewProvider(nil, Metrics)
-	newService := CreateRetryUpdateService(r.pruner, WithRetries(r.config.retries), WithInterval(r.config.interval), WithIntervalMultiplier(8), WithMeasures(p))
-	assert.Equal(r.pruner, newService.pruner)
-	assert.Equal(r.config.retries, newService.config.retries)
-	assert.Equal(r.config.interval, newService.config.interval)
-	assert.Equal(r.config.intervalMult, newService.config.intervalMult)
-}
-
-func TestRetryGetBlacklist(t *testing.T) {
-	initialErr := errors.New("test initial error")
-	failureErr := errors.New("test final error")
-	interval := 8 * time.Second
-	tests := []struct {
-		description         string
-		numCalls            int
-		retries             int
-		expectedRetryMetric float64
-		finalError          error
-		expectedErr         error
-	}{
-		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
-		},
-		{
-			description:         "Eventual Success",
-			numCalls:            3,
-			retries:             5,
-			expectedRetryMetric: 2.0,
-			finalError:          nil,
-			expectedErr:         nil,
-		},
-		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
-			description:         "Eventual Failure",
-			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
-			finalError:          failureErr,
-			expectedErr:         failureErr,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			mockObj := new(mockLG)
-			if tc.numCalls > 1 {
-				mockObj.On("GetBlacklist").Return([]blacklist.BlackListedItem{}, initialErr).Times(tc.numCalls - 1)
-			}
-			if tc.numCalls > 0 {
-				mockObj.On("GetBlacklist").Return([]blacklist.BlackListedItem{}, tc.finalError).Once()
-			}
-			p := xmetricstest.NewProvider(nil, Metrics)
-			m := NewMeasures(p)
-
-			retryListGService := RetryListGService{
-				lg: mockObj,
-				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
-					},
-					measures: m,
-				},
-			}
-			p.Assert(t, SQLQueryRetryCounter)(xmetricstest.Value(0.0))
-			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
-			_, err := retryListGService.GetBlacklist()
-			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.BlacklistReadType)(xmetricstest.Value(tc.expectedRetryMetric))
-			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.BlacklistReadType)(xmetricstest.Value(1.0))
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-
-}
-
-func TestCreateRetryListGService(t *testing.T) {
-	r := RetryListGService{
-		lg: new(mockLG),
-		config: retryConfig{
-			retries:      322,
-			interval:     2 * time.Minute,
-			intervalMult: 5,
-		},
-	}
-	assert := assert.New(t)
-	p := xmetricstest.NewProvider(nil, Metrics)
-	newService := CreateRetryListGService(r.lg, WithRetries(r.config.retries), WithInterval(r.config.interval), WithIntervalMultiplier(5), WithMeasures(p))
-	assert.Equal(r.lg, newService.lg)
-	assert.Equal(r.config.retries, newService.config.retries)
-	assert.Equal(r.config.interval, newService.config.interval)
-	assert.Equal(r.config.intervalMult, newService.config.intervalMult)
-}
-
-func TestRetryGetRecords(t *testing.T) {
-	initialErr := errors.New("test initial error")
-	failureErr := errors.New("test final error")
-	interval := 8 * time.Second
-	tests := []struct {
-		description         string
-		numCalls            int
-		retries             int
-		expectedRetryMetric float64
-		finalError          error
-		expectedErr         error
-	}{
-		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
-		},
-		{
-			description:         "Eventual Success",
-			numCalls:            3,
-			retries:             5,
-			expectedRetryMetric: 2.0,
-			finalError:          nil,
-			expectedErr:         nil,
-		},
-		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
-			description:         "Eventual Failure",
-			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
-			finalError:          failureErr,
-			expectedErr:         failureErr,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			mockObj := new(mockRG)
-			if tc.numCalls > 1 {
-				mockObj.On("GetRecords", mock.Anything, mock.Anything).Return([]db.Record{}, initialErr).Times(tc.numCalls - 1)
-			}
-			if tc.numCalls > 0 {
-				mockObj.On("GetRecords", mock.Anything, mock.Anything).Return([]db.Record{}, tc.finalError).Once()
-			}
-			p := xmetricstest.NewProvider(nil, Metrics)
-			m := NewMeasures(p)
-
-			retryRGService := RetryRGService{
-				rg: mockObj,
-				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
-					},
-					measures: m,
-				},
-			}
-			p.Assert(t, SQLQueryRetryCounter)(xmetricstest.Value(0.0))
-			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
-			_, err := retryRGService.GetRecords("", 5)
-			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(tc.expectedRetryMetric))
-			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(1.0))
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-
-}
-
-func TestRetryGetRecordsOfType(t *testing.T) {
-	initialErr := errors.New("test initial error")
-	failureErr := errors.New("test final error")
-	interval := 8 * time.Second
-	tests := []struct {
-		description         string
-		numCalls            int
-		retries             int
-		expectedRetryMetric float64
-		finalError          error
-		expectedErr         error
-	}{
-		{
-			description: "Initial Success",
-			numCalls:    1,
-			retries:     1,
-			finalError:  nil,
-			expectedErr: nil,
-		},
-		{
-			description:         "Eventual Success",
-			numCalls:            3,
-			retries:             5,
-			expectedRetryMetric: 2.0,
-			finalError:          nil,
-			expectedErr:         nil,
-		},
-		{
-			description: "Initial Failure",
-			numCalls:    1,
-			retries:     0,
-			finalError:  failureErr,
-			expectedErr: failureErr,
-		},
-		{
-			description:         "Eventual Failure",
-			numCalls:            4,
-			retries:             3,
-			expectedRetryMetric: 3.0,
-			finalError:          failureErr,
-			expectedErr:         failureErr,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			mockObj := new(mockRG)
-			if tc.numCalls > 1 {
-				mockObj.On("GetRecordsOfType", mock.Anything, mock.Anything, mock.Anything).Return([]db.Record{}, initialErr).Times(tc.numCalls - 1)
-			}
-			if tc.numCalls > 0 {
-				mockObj.On("GetRecordsOfType", mock.Anything, mock.Anything, mock.Anything).Return([]db.Record{}, tc.finalError).Once()
-			}
-			p := xmetricstest.NewProvider(nil, Metrics)
-			m := NewMeasures(p)
-
-			retryRGService := RetryRGService{
-				rg: mockObj,
-				config: retryConfig{
-					retries:      tc.retries,
-					interval:     interval,
-					intervalMult: 1,
-					sleep: func(t time.Duration) {
-						assert.Equal(interval, t)
-					},
-					measures: m,
-				},
-			}
-			p.Assert(t, SQLQueryRetryCounter)(xmetricstest.Value(0.0))
-			p.Assert(t, SQLQueryEndCounter)(xmetricstest.Value(0.0))
-			_, err := retryRGService.GetRecordsOfType("", 5, 0)
-			mockObj.AssertExpectations(t)
-			p.Assert(t, SQLQueryRetryCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(tc.expectedRetryMetric))
-			p.Assert(t, SQLQueryEndCounter, db.TypeLabel, db.ReadType)(xmetricstest.Value(1.0))
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-
-}
-
-func TestCreateRetryRGService(t *testing.T) {
-	r := RetryRGService{
-		rg: new(mockRG),
-		config: retryConfig{
-			retries:      322,
-			interval:     2 * time.Minute,
-			intervalMult: 5,
-		},
-	}
-	assert := assert.New(t)
-	p := xmetricstest.NewProvider(nil, Metrics)
-	newService := CreateRetryRGService(r.rg, WithRetries(r.config.retries), WithInterval(r.config.interval), WithIntervalMultiplier(5), WithMeasures(p))
-	assert.Equal(r.rg, newService.rg)
-	assert.Equal(r.config.retries, newService.config.retries)
-	assert.Equal(r.config.interval, newService.config.interval)
-	assert.Equal(r.config.intervalMult, newService.config.intervalMult)
+	newService := CreateRetryInsertService(r.inserter, WithBackoff(r.config.backoffConfig), WithMeasures(nil))
+	assert.Equal(r.inserter, newService.inserter)
+	assert.Equal(backoff.NewExponentialBackOff().InitialInterval, newService.config.backoffConfig.InitialInterval)
+	assert.Equal(backoff.NewExponentialBackOff().RandomizationFactor, newService.config.backoffConfig.RandomizationFactor)
+	assert.Equal(backoff.NewExponentialBackOff().Multiplier, newService.config.backoffConfig.Multiplier)
+	assert.Equal(backoff.NewExponentialBackOff().MaxInterval, newService.config.backoffConfig.MaxInterval)
+	assert.Equal(backoff.NewExponentialBackOff().MaxElapsedTime, newService.config.backoffConfig.MaxElapsedTime)
+	assert.Equal(backoff.NewExponentialBackOff().Clock, newService.config.backoffConfig.Clock)
 }


### PR DESCRIPTION
Fixes https://github.com/xmidt-org/codex-db/issues/20.

Most important differences:
- Instead of a number of retries, we have a maximum amount of time we want to spend trying to insert the records.  This means things that fail fast will retry more than things that fail slowly (such as due to timeouts).
- Now we have jitter, so if many inserts happen at the same time and are failing, the load will be better spread out over time.

Still need to:
- [x] add validation of config values back
- [x] review comments and ensure they are accurate
- [x] fix unit tests